### PR TITLE
update executeboosted reward function

### DIFF
--- a/contracts/votingMachines/GenesisProtocolLogic.sol
+++ b/contracts/votingMachines/GenesisProtocolLogic.sol
@@ -72,9 +72,8 @@ contract GenesisProtocolLogic is IntVoteInterface {
         uint256 daoBounty;
         uint256 totalStakes;// Total number of tokens staked which can be redeemable by stakers.
         uint256 confidenceThreshold;
-        //The percentage from upper stakes which the caller for the expiration was given.
-        //in 1/10 units (e.g a value of 7 means 0.7 %)
-        uint256 expirationCallBountyPercentage;
+        //The promille from upper stakes which the caller for the expiration was given.
+        uint256 expirationCallBountyProMille;
         uint[3] times; //times[0] - submittedTime
                        //times[1] - boostedPhaseTime
                        //times[2] -preBoostedPhaseTime;
@@ -237,7 +236,7 @@ contract GenesisProtocolLogic is IntVoteInterface {
             blocksSinceTimeOut = 100;
         }
 
-        proposal.expirationCallBountyPercentage = blocksSinceTimeOut;
+        proposal.expirationCallBountyProMille = blocksSinceTimeOut;
         expirationCallBounty = calcExecuteCallBounty(_proposalId);
         require(stakingToken.transfer(msg.sender, expirationCallBounty), "transfer to msg.sender failed");
         emit ExpirationCallBounty(_proposalId, msg.sender, expirationCallBounty);
@@ -439,7 +438,7 @@ contract GenesisProtocolLogic is IntVoteInterface {
       * @return uint256 executeCallBounty
     */
     function calcExecuteCallBounty(bytes32 _proposalId) public view returns(uint256) {
-        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
+        return proposals[_proposalId].expirationCallBountyProMille.mul(proposals[_proposalId].stakes[YES]).div(1000);
     }
 
     /**

--- a/contracts/votingMachines/GenesisProtocolLogic.sol
+++ b/contracts/votingMachines/GenesisProtocolLogic.sol
@@ -305,6 +305,15 @@ contract GenesisProtocolLogic is IntVoteInterface {
     }
 
     /**
+      * @dev calcExecuteCallBounty calculate the execute boosted call bounty
+      * @param _proposalId the ID of the proposal
+      * @return uint256 executeCallBounty
+    */
+    function calcExecuteCallBounty(bytes32 _proposalId) external view returns(uint256) {
+        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
+    }
+
+    /**
      * @dev redeem a reward for a successful stake, vote or proposing.
      * The function use a beneficiary address as a parameter (and not msg.sender) to enable
      * users to redeem on behalf of someone else.
@@ -756,14 +765,5 @@ contract GenesisProtocolLogic is IntVoteInterface {
                 (pState == ProposalState.QuietEndingPeriod)||
                 (pState == ProposalState.Queued)
         );
-    }
-
-    /**
-      * @dev calcExecuteCallBounty calculate the execute boosted call bounty
-      * @param _proposalId the ID of the proposal
-      * @return uint256 executeCallBounty
-    */
-    function calcExecuteCallBounty(bytes32 _proposalId) private view returns(uint256) {
-        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
     }
 }

--- a/contracts/votingMachines/GenesisProtocolLogic.sol
+++ b/contracts/votingMachines/GenesisProtocolLogic.sol
@@ -73,6 +73,7 @@ contract GenesisProtocolLogic is IntVoteInterface {
         uint256 totalStakes;// Total number of tokens staked which can be redeemable by stakers.
         uint256 confidenceThreshold;
         //The percentage from upper stakes which the caller for the expiration was given.
+        //in 1/10 units (e.g a value of 7 means 0.7 %)
         uint256 expirationCallBountyPercentage;
         uint[3] times; //times[0] - submittedTime
                        //times[1] - boostedPhaseTime
@@ -216,6 +217,10 @@ contract GenesisProtocolLogic is IntVoteInterface {
 
     /**
       * @dev executeBoosted try to execute a boosted or QuietEndingPeriod proposal if it is expired
+      * it rewards the msg.sender with P % of the proposal's upstakes upon a successful call to this function.
+      * P = t/10 and t = number of blocks passed between the proposal's timeout and a successful call to this function.
+      * the function assume an avergae block time of 15 seconds.
+      * max P is 10 %.
       * @param _proposalId the id of the proposal
       * @return uint256 expirationCallBounty the bounty amount for the expiration call
      */
@@ -224,14 +229,16 @@ contract GenesisProtocolLogic is IntVoteInterface {
         require(proposal.state == ProposalState.Boosted || proposal.state == ProposalState.QuietEndingPeriod,
         "proposal state in not Boosted nor QuietEndingPeriod");
         require(_execute(_proposalId), "proposal need to expire");
-        uint256 expirationCallBountyPercentage =
+        uint256 blocksSinceTimeOut =
         // solhint-disable-next-line not-rely-on-time
-        (uint(1).add(now.sub(proposal.currentBoostedVotePeriodLimit.add(proposal.times[1])).div(15)));
-        if (expirationCallBountyPercentage > 100) {
-            expirationCallBountyPercentage = 100;
+            now.sub(proposal.currentBoostedVotePeriodLimit.add(proposal.times[1])).div(15);
+
+        if (blocksSinceTimeOut > 100) {
+            blocksSinceTimeOut = 100;
         }
-        proposal.expirationCallBountyPercentage = expirationCallBountyPercentage;
-        expirationCallBounty = expirationCallBountyPercentage.mul(proposal.stakes[YES]).div(100);
+
+        proposal.expirationCallBountyPercentage = blocksSinceTimeOut;
+        expirationCallBounty = calcExecuteCallBounty(_proposalId);
         require(stakingToken.transfer(msg.sender, expirationCallBounty), "transfer to msg.sender failed");
         emit ExpirationCallBounty(_proposalId, msg.sender, expirationCallBounty);
     }
@@ -314,21 +321,13 @@ contract GenesisProtocolLogic is IntVoteInterface {
         require((proposal.state == ProposalState.Executed)||(proposal.state == ProposalState.ExpiredInQueue),
         "Proposal should be Executed or ExpiredInQueue");
         Parameters memory params = parameters[proposal.paramsHash];
-        uint256 lostReputation;
-        if (proposal.winningVote == YES) {
-            lostReputation = proposal.preBoostedVotes[NO];
-        } else {
-            lostReputation = proposal.preBoostedVotes[YES];
-        }
-        lostReputation = (lostReputation.mul(params.votersReputationLossRatio))/100;
         //as staker
         Staker storage staker = proposal.stakers[_beneficiary];
-        uint256 totalStakes = proposal.stakes[NO].add(proposal.stakes[YES]);
         uint256 totalWinningStakes = proposal.stakes[proposal.winningVote];
-
+        uint256 totalStakesLeftAfterCallBounty =
+        proposal.stakes[NO].add(proposal.stakes[YES]).sub(calcExecuteCallBounty(_proposalId));
         if (staker.amount > 0) {
-            uint256 totalStakesLeftAfterCallBounty =
-            totalStakes.sub(proposal.expirationCallBountyPercentage.mul(proposal.stakes[YES]).div(100));
+
             if (proposal.state == ProposalState.ExpiredInQueue) {
                 //Stakes of a proposal that expires in Queue are sent back to stakers
                 rewards[0] = staker.amount;
@@ -350,7 +349,9 @@ contract GenesisProtocolLogic is IntVoteInterface {
             proposal.state != ProposalState.ExpiredInQueue &&
             proposal.winningVote == NO) {
             rewards[0] =
-            rewards[0].add((proposal.daoBounty.mul(totalStakes))/totalWinningStakes).sub(proposal.daoBounty);
+            rewards[0]
+            .add((proposal.daoBounty.mul(totalStakesLeftAfterCallBounty))/totalWinningStakes)
+            .sub(proposal.daoBounty);
             proposal.daoRedeemItsWinnings = true;
         }
 
@@ -361,6 +362,13 @@ contract GenesisProtocolLogic is IntVoteInterface {
               //give back reputation for the voter
                 rewards[1] = ((voter.reputation.mul(params.votersReputationLossRatio))/100);
             } else if (proposal.winningVote == voter.vote) {
+                uint256 lostReputation;
+                if (proposal.winningVote == YES) {
+                    lostReputation = proposal.preBoostedVotes[NO];
+                } else {
+                    lostReputation = proposal.preBoostedVotes[YES];
+                }
+                lostReputation = (lostReputation.mul(params.votersReputationLossRatio))/100;
                 rewards[1] = ((voter.reputation.mul(params.votersReputationLossRatio))/100)
                 .add((voter.reputation.mul(lostReputation))/proposal.preBoostedVotes[proposal.winningVote]);
             }
@@ -748,5 +756,14 @@ contract GenesisProtocolLogic is IntVoteInterface {
                 (pState == ProposalState.QuietEndingPeriod)||
                 (pState == ProposalState.Queued)
         );
+    }
+
+    /**
+      * @dev calcExecuteCallBounty calculate the execute boosted call bounty
+      * @param _proposalId the ID of the proposal
+      * @return uint256 executeCallBounty
+    */
+    function calcExecuteCallBounty(bytes32 _proposalId) private view returns(uint256) {
+        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
     }
 }

--- a/contracts/votingMachines/GenesisProtocolLogic.sol
+++ b/contracts/votingMachines/GenesisProtocolLogic.sol
@@ -305,15 +305,6 @@ contract GenesisProtocolLogic is IntVoteInterface {
     }
 
     /**
-      * @dev calcExecuteCallBounty calculate the execute boosted call bounty
-      * @param _proposalId the ID of the proposal
-      * @return uint256 executeCallBounty
-    */
-    function calcExecuteCallBounty(bytes32 _proposalId) external view returns(uint256) {
-        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
-    }
-
-    /**
      * @dev redeem a reward for a successful stake, vote or proposing.
      * The function use a beneficiary address as a parameter (and not msg.sender) to enable
      * users to redeem on behalf of someone else.
@@ -440,6 +431,15 @@ contract GenesisProtocolLogic is IntVoteInterface {
             redeemedAmount = potentialAmount;
             emit RedeemDaoBounty(_proposalId, organizations[proposal.organizationId], _beneficiary, redeemedAmount);
         }
+    }
+
+    /**
+      * @dev calcExecuteCallBounty calculate the execute boosted call bounty
+      * @param _proposalId the ID of the proposal
+      * @return uint256 executeCallBounty
+    */
+    function calcExecuteCallBounty(bytes32 _proposalId) public view returns(uint256) {
+        return proposals[_proposalId].expirationCallBountyPercentage.mul(proposals[_proposalId].stakes[YES]).div(1000);
     }
 
     /**

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -304,7 +304,7 @@ contract('GenesisProtocol', accounts => {
                                           testSetup.genesisProtocolParams.paramsHash,
                                           daoBountyRemain,
                                           0, //daoBounty
-                                          daoBountyRemain, //totalStake (dao downstake)
+                                          0, //totalStake
                                           0,
                                           0,
                                         ],
@@ -331,7 +331,7 @@ contract('GenesisProtocol', accounts => {
                                             testSetup.genesisProtocolParams.paramsHash,
                                             daoBountyRemain,
                                             0, //daoBounty
-                                            daoBountyRemain, //totalStake (dao downstake)
+                                            0, //totalStake
                                             0,
                                             0
                                           ],
@@ -357,7 +357,7 @@ contract('GenesisProtocol', accounts => {
                                             testSetup.genesisProtocolParams.paramsHash,
                                             daoBountyRemain,
                                             0, //daoBounty
-                                            daoBountyRemain, //totalStake (dao downstake)
+                                            0, //totalStake
                                             0,
                                             0
                                           ],
@@ -677,7 +677,7 @@ contract('GenesisProtocol', accounts => {
                                           testSetup.genesisProtocolParams.paramsHash,
                                           daoBountyRemain,
                                           0, //daoBounty
-                                          daoBountyRemain, //totalStake (dao downstake)
+                                          0, //totalStake
                                           0,
                                           0
                                           ],
@@ -824,23 +824,21 @@ contract('GenesisProtocol', accounts => {
 
     var proposalId = await propose(testSetup);
 
-    var proposalStatus  = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    let maxTotalStakeAllowed = ((new BigNumber(2)).toPower(128));
-    let maxTotalStakesRemain = maxTotalStakeAllowed.sub(proposalStatus[3]);
+    let maxTotalStakeAllowed = ((new BigNumber(2)).toPower(128)).sub(15);
 
     try {
-        await stake(testSetup,proposalId,1,maxTotalStakesRemain.add(1).toString(10),accounts[0]);
+        await stake(testSetup,proposalId,1,maxTotalStakeAllowed.add(1).toString(10),accounts[0]);
         assert(false, 'stake more than allowed should revert');
       } catch (ex) {
         helpers.assertVMException(ex);
       }
 
-    var tx = await stake(testSetup,proposalId,1,maxTotalStakesRemain.toString(10),accounts[0]);
+    var tx = await stake(testSetup,proposalId,1,maxTotalStakeAllowed.toString(10),accounts[0]);
     assert.equal(tx.length, 1);
     assert.equal(tx[0].event, "Stake");
     assert.equal(tx[0].args._staker, accounts[0]);
     assert.equal(tx[0].args._vote, 1);
-    assert.equal(tx[0].args._amount, maxTotalStakesRemain.toString(10));
+    assert.equal(tx[0].args._amount, maxTotalStakeAllowed.toString(10));
   });
 
   it("stake log", async () => {
@@ -959,7 +957,7 @@ contract('GenesisProtocol', accounts => {
     assert.equal(staker[1],20);
 
     let proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[9],20+15); //totalStakes + dao downstake
+    assert.equal(proposalInfo[9],20); //totalStakes + dao downstake
   });
 
   it("stake without approval - fail", async () => {
@@ -1006,7 +1004,7 @@ contract('GenesisProtocol', accounts => {
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),false);
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],boostedState);  //state boosted
     //S = (S+) /(S-)
     var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
@@ -1029,7 +1027,7 @@ contract('GenesisProtocol', accounts => {
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),false);
     await stake(testSetup,proposalId,YES,30,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],30+2); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],30); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],boostedState);  //state boosted
     //S = (S+) /(S-)
     var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
@@ -1068,7 +1066,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
 
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],boostedState);   //state boosted
 
     //S* POW(R/totalR)
@@ -1092,7 +1090,7 @@ contract('GenesisProtocol', accounts => {
     assert.equal(score,0);
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],boostedState);   //state boosted
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
@@ -1116,7 +1114,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
 
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     const organizationId = await web3.utils.soliditySha3(testSetup.genesisProtocolCallbacks.address,helpers.NULL_ADDRESS);
     assert.equal(proposalInfo[proposalStateIndex],boostedState);   //state boosted
     assert.equal(await testSetup.genesisProtocol.averagesDownstakesOfBoosted(organizationId),15);
@@ -1155,7 +1153,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
 
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     const organizationId = await web3.utils.soliditySha3(testSetup.genesisProtocolCallbacks.address,helpers.NULL_ADDRESS);
     assert.equal(proposalInfo[proposalStateIndex],boostedState);   //state boosted
     assert.equal(await testSetup.genesisProtocol.averagesDownstakesOfBoosted(organizationId),15);
@@ -1204,10 +1202,10 @@ contract('GenesisProtocol', accounts => {
     var redeemToken = redeemRewards[0].toNumber();
     assert.equal(redeemToken,((100+15-15)*100)/100);
     assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),accounts0Balance-100);
-    assert.equal(proposalInfo[9],100+15);
+    assert.equal(proposalInfo[9],100);
     var tx = await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[9],15);
+    assert.equal(proposalInfo[9],0);
     assert.equal(tx.logs.length,2);
     assert.equal(tx.logs[0].event, "Redeem");
     assert.equal(tx.logs[0].args._proposalId, proposalId);
@@ -1561,7 +1559,7 @@ contract('GenesisProtocol', accounts => {
       var redeemToken = redeemRewards[0].toNumber();
       var tx = await testSetup.genesisProtocol.redeem(proposalId,testSetup.genesisProtocolCallbacks.address);
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[9],15);
+      assert.equal(proposalInfo[9],0);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event, "Redeem");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
@@ -1587,7 +1585,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
 
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
 
     assert.equal(proposalInfo[proposalStateIndex],preBoostedState);   //state pre boosted
 
@@ -1611,7 +1609,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
 
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
 
     assert.equal(proposalInfo[proposalStateIndex],preBoostedState);   //state pre boosted
     assert.equal(proposalInfo[10],Math.pow(2,REAL_FBITS));//check proposal own threshold
@@ -1634,7 +1632,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,50,accounts[0]);
 
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],50+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],50); //totalStakes
 
     assert.equal(proposalInfo[proposalStateIndex],preBoostedState);   //state pre boosted
     assert.equal(proposalInfo[10],Math.pow(2,REAL_FBITS));//check proposal own threshold
@@ -1675,7 +1673,7 @@ contract('GenesisProtocol', accounts => {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
 
     var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],100+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],100); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],preBoostedState);   //state pre boosted
     assert.equal(proposalInfo[10],3*Math.pow(2,REAL_FBITS));//check proposal own threshold
 
@@ -1711,7 +1709,7 @@ contract('GenesisProtocol', accounts => {
     //preboost proposalId
     await stake(testSetup,proposalId,YES,60,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[proposalTotalStakesIndex],60+15); //totalStakes
+    assert.equal(proposalInfo[proposalTotalStakesIndex],60); //totalStakes
     assert.equal(proposalInfo[proposalStateIndex],preBoostedState);   //state pre boosted
     await helpers.increaseTime(preBoostedVotePeriodLimit/2 +1 );
     await testSetup.genesisProtocol.execute(proposalId2);
@@ -1777,6 +1775,8 @@ contract('GenesisProtocol', accounts => {
     var _totalStakes = totalStakesLeftAfterCallBounty - daoBounty;
     assert.equal(redeemToken.toString(),_totalStakes.toString());
     await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
+    proposalInfo =  await testSetup.genesisProtocol.proposals(proposalId);
+    assert.equal(proposalInfo.totalStakes,0);
     assert.equal(await testSetup.stakingToken.balanceOf(testSetup.genesisProtocol.address),0);
   });
 
@@ -1815,7 +1815,9 @@ contract('GenesisProtocol', accounts => {
     await helpers.increaseTime(60+addTime);
     assert.equal((await testSetup.stakingToken.balanceOf(testSetup.genesisProtocol.address)).toString(),totalStakes.toString());
     var tx = await testSetup.genesisProtocol.executeBoosted(proposalId);
-
+    addTime = (await testSetup.genesisProtocol.proposals(proposalId)).secondsFromTimeOutTillExecuteBoosted.toNumber();
+    //check the time is in a resonable range
+    assert.equal(((addTime <= 18) && (addTime >=15)),true);
     var expectedBounty = new web3.utils.BN((addTime*user2Stake/15000).toString());
     assert.equal(tx.logs[3].event, "ExpirationCallBounty");
     assert.equal(tx.logs[3].args._proposalId, proposalId);

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -134,7 +134,7 @@ const checkProposalInfo = async function(proposalId, _proposalInfo,_times,genesi
   assert.equal(proposalInfo[9], _proposalInfo[9]);
   //int threshold
   assert.equal(proposalInfo[10], _proposalInfo[10]);
-  //uint expirationCallBountyPercentage
+  //uint expirationCallBountyProMille
   assert.equal(proposalInfo[11], _proposalInfo[11]);
   // - the mapping and array are simply not returned at all in the array
   checkProposalTimes(proposalId,_times,genesisProtocol);
@@ -1769,8 +1769,8 @@ contract('GenesisProtocol', accounts => {
     var redeemToken = redeemRewards[0];
 
     var proposalInfo =  await testSetup.genesisProtocol.proposals(proposalId);
-    var expirationCallBountyPercentage = proposalInfo[11];
-    assert.equal(expirationCallBountyPercentage,addTime/15);
+    var expirationCallBountyProMille = proposalInfo[11];
+    assert.equal(expirationCallBountyProMille,addTime/15);
     var daoBounty =  new web3.utils.BN(minimumDaoBounty);
     var totalStakes = (new web3.utils.BN(userStake)).add(daoBounty);
     var totalStakesLeftAfterCallBounty = totalStakes.sub(new web3.utils.BN(expectedBounty));
@@ -1820,7 +1820,7 @@ contract('GenesisProtocol', accounts => {
     assert.equal(tx.logs[3].args._proposalId, proposalId);
     assert.equal(tx.logs[3].args._beneficiary, accounts[0]);
     assert.equal(tx.logs[3].args._amount, expectedBounty.toString());
-    assert.equal((await testSetup.genesisProtocol.proposals(proposalId)).expirationCallBountyPercentage.toNumber(),1);
+    assert.equal((await testSetup.genesisProtocol.proposals(proposalId)).expirationCallBountyProMille.toNumber(),1);
     var totalStakesLeftAfterCallBounty = (new web3.utils.BN(totalStakes)).sub(expectedBounty);
     assert.equal((await testSetup.stakingToken.balanceOf(testSetup.genesisProtocol.address)).eq(totalStakesLeftAfterCallBounty),true);
     await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);


### PR DESCRIPTION
- it rewards the msg.sender with P % of the proposal's upstakes upon a successful call to this function.
P = t/10 and t = number of blocks passed between the proposal's timeout and a successful call to this function. max P is 10 %.
- fix a bug at redeem function 
  the bug manifest itself when a dao/scheme will try to redeem its downstakes winning from a failed proposals and only if there is already a reward payout for executeboosted call. in some cases it might cause the redeem call to revert so the dao/scheme could not redeem its winning.

